### PR TITLE
Enable additional results output for pair_align_functions_bayes.R

### DIFF
--- a/R/pair_align_functions_bayes.R
+++ b/R/pair_align_functions_bayes.R
@@ -21,6 +21,7 @@
 #' \item{dist_collect}{posterior samples from the distances (returned if extrainfo=TRUE)}
 #' \item{kappa_collect}{posterior samples from kappa (returned if extrainfo=TRUE)}
 #' \item{log_collect}{log-likelihood of each sample (returned if extrainfo=TRUE)}
+#' \item{pct_accept}{vector of acceptance ratios for the warping function (returned if extrainfo=TRUE)}
 #' @keywords srsf alignment, bayesian
 #' @references Cheng, W., Dryden, I. L., and Huang, X. (2016). Bayesian
 #' registration of functions and curves. Bayesian Analysis, 11(2), 447-475.
@@ -163,6 +164,7 @@ pair_align_functions_bayes <- function(f1, f2, timet, iter=15000, times = 5,
     retVal$dist_collect <- dist_collect
     retVal$kappa_collect <- kappa_collect
     retVal$log_collect <- log_collect
+    retVal$pct_accept <- res$pct_accept
   }
   return(retVal)
 }

--- a/man/pair_align_functions_bayes.Rd
+++ b/man/pair_align_functions_bayes.Rd
@@ -5,7 +5,8 @@
 \title{Align two functions}
 \usage{
 pair_align_functions_bayes(f1, f2, timet, iter = 15000, times = 5,
-  tau = ceiling(times * 0.4), powera = 1, showplot = TRUE)
+  tau = ceiling(times * 0.4), powera = 1, showplot = TRUE,
+  extrainfo = FALSE)
 }
 \arguments{
 \item{f1}{function 1}
@@ -23,6 +24,8 @@ pair_align_functions_bayes(f1, f2, timet, iter = 15000, times = 5,
 \item{powera}{Dirchelet prior parameter (default 1)}
 
 \item{showplot}{shows plots of functions (default = T)}
+
+\item{extrainfo}{T/F whether additional information is returned}
 }
 \value{
 Returns a list containing \item{f1}{function 1}
@@ -30,6 +33,10 @@ Returns a list containing \item{f1}{function 1}
 \item{gam_q}{warping function quotient space}
 \item{f2_a}{registered fucntion using ambient space}
 \item{q2_a}{warping function ambient space}
+\item{match_collect}{posterior samples from warping function (returned if extrainfo=TRUE)}
+\item{dist_collect}{posterior samples from the distances (returned if extrainfo=TRUE)}
+\item{kappa_collect}{posterior samples from kappa (returned if extrainfo=TRUE)}
+\item{log_collect}{log-likelihood of each sample (returned if extrainfo=TRUE)}
 }
 \description{
 This function aligns two functions using Bayesian SRSF framework. It will align f2

--- a/man/pair_align_functions_bayes.Rd
+++ b/man/pair_align_functions_bayes.Rd
@@ -37,6 +37,7 @@ Returns a list containing \item{f1}{function 1}
 \item{dist_collect}{posterior samples from the distances (returned if extrainfo=TRUE)}
 \item{kappa_collect}{posterior samples from kappa (returned if extrainfo=TRUE)}
 \item{log_collect}{log-likelihood of each sample (returned if extrainfo=TRUE)}
+\item{pct_accept}{vector of acceptance ratios for the warping function (returned if extrainfo=TRUE)}
 }
 \description{
 This function aligns two functions using Bayesian SRSF framework. It will align f2

--- a/src/fdasrsf/bayesian.cpp
+++ b/src/fdasrsf/bayesian.cpp
@@ -276,8 +276,8 @@ RcppExport SEXP simucode(SEXP R_iter, SEXP R_p, SEXP R_qt1_5, SEXP R_qt2_5,
   return (List::create(Named("best_match")=Rr_best_match,
                        Named("match_collect")=Rr_match_collect,
                        Named("dist_collect")=dist_collect,
-                       Named("kappafamily")=kappa_collect,
-                       Named("log.posterior")=log_collect,
+                       Named("kappa_collect")=kappa_collect,
+                       Named("log_collect")=log_collect,
                        Named("dist_min")=dist_min));
 }
 


### PR DESCRIPTION
I added the argument extrainfo which defaults to false. If set to true, then sampling chains for multiple parameters are returned, as well as acceptance ratios for the warping functions. Specifically, chains are returned for kappa, the distance, the log-likelihood, and the warping functions. The acceptance ratios returns a vector with ratios for each element in the (downsampled) warping function, except the two end-points which do not change.