### PR TITLE
Correct some numerical precision in gamma_mat

### DIFF
--- a/R/pair_align_functions_expomap.R
+++ b/R/pair_align_functions_expomap.R
@@ -542,6 +542,9 @@ pair_align_functions_expomap <- function(f1,
     stop('Length of init.coef must be even')
   }
 
+  # Number of sig figs to report in gamma_mat
+  SIG_GAM <- 13
+
   # for now, back to list format of Yi's software
   f1 <- list(x = timet, y = f1)
   f2 <- list(x = timet, y = f2)
@@ -736,7 +739,8 @@ pair_align_functions_expomap <- function(f1,
                            xout = f1$x,
                            rule = 2
                          )
-                         with(resamp, f.phiinv(list(x = x, y = y)))$y
+                         rawgam <- with(resamp, f.phiinv(list(x = x, y = y)))$y
+                         round(rawgam, SIG_GAM)
                        })
 
     # x-distance, adapted from fdasrvf::elastic.distance


### PR DESCRIPTION
The function f.phiinv() appears to introduce numerical imprecision on the scale of +/- 1e15. This can introduce values for gamma slightly beyond the interval [0,1], which can be problematic for subsequent analysis. Rounding to the nearest 13th decimal place solves the issue.