### PR TITLE
Normalize gamma matrix to interval [0,1]

### DIFF
--- a/R/pair_align_functions_expomap.R
+++ b/R/pair_align_functions_expomap.R
@@ -450,6 +450,10 @@ f.phiinv <- function(psi) {
 }
 
 
+# Normalize gamma to [0,1]
+norm_gam <- function(gam) {
+  (gam-gam[1]) / (gam[length(gam)]-gam[1])
+}
 
 
 #' Align two functions using geometric properties of warping functions
@@ -718,7 +722,7 @@ pair_align_functions_expomap <- function(f1,
   ### aim to replace this by gamma mean below
   result.posterior.gamma <- f.phiinv(result.posterior.psi)
   gam0 <- result.posterior.gamma$y
-  result.posterior.gamma$y <- (gam0-gam0[1])/(gam0[length(gam0)]-gam0[1])
+  result.posterior.gamma$y <- norm_gam(gam0)
 
   # warped f2
   f2.warped <-
@@ -741,6 +745,7 @@ pair_align_functions_expomap <- function(f1,
                            rule = 2
                          )
                          rawgam <- with(resamp, f.phiinv(list(x = x, y = y)))$y
+                         rawgam <- norm_gam(rawgam)
                          round(rawgam, SIG_GAM)
                        })
 

--- a/tests/testthat/test_pair_align_functions_expomap.R
+++ b/tests/testthat/test_pair_align_functions_expomap.R
@@ -15,11 +15,11 @@ testthat::test_that("Verify pair_align_functions_expomap() works as intended", {
   testthat::expect_equal(mean(out$g.coef), 0.0009790850138)
   testthat::expect_equal(mean(out$psi$y), 0.9994264515)
   testthat::expect_equal(mean(out$sigma1), 0.1190701554)
-  testthat::expect_equal(mean(out$gamma_q025), 0.5047645724)
-  testthat::expect_equal(mean(out$gamma_q975), 0.5121841722)
-  testthat::expect_equal(mean(out$gamma_mat), 0.5083537445)
-  testthat::expect_equal(sd(out$xdist), 0.0032652812)
-  testthat::expect_equal(sd(out$ydist), 0.0028818982)
+  testthat::expect_equal(mean(out$gamma_q025), 0.5047707865)
+  testthat::expect_equal(mean(out$gamma_q975), 0.5121903483)
+  testthat::expect_equal(mean(out$gamma_mat), 0.5083599893)
+  testthat::expect_equal(sd(out$xdist), 0.003265281265)
+  testthat::expect_equal(sd(out$ydist), 0.002882380796)
   # verify functions match approximately
   testthat::expect_equal(sum(simu_data$f[,1] - out$f2_warped), -10.31959727)
   # verify acceptance rate


### PR DESCRIPTION
Apply normalization from MAP gamma estimate line 721 to gamma matrix.