### PR TITLE
navigate rounding errors in inv_exp_map()

### DIFF
--- a/R/geometry.R
+++ b/R/geometry.R
@@ -9,7 +9,13 @@ l2_curvenorm <- function(psi, time=seq(0,1,length.out=ncol(psi))){
 }
 
 inv_exp_map<-function(Psi, psi){
-  theta <- acos(inner_product(Psi,psi))
+  ip <- inner_product(Psi, psi)
+  if(ip < -1){
+    ip = -1
+  }else if(ip > 1){
+    ip = 1
+  }
+  theta <- acos(ip)
 
   if (theta < 1e-10){
     exp_inv = rep(0,length(psi))


### PR DESCRIPTION
With the recent changes to smooth derivative calculations, "ip" was sometimes very very slightly greater than 1 (appeared to be 1 with machine precision), so acos(ip) threw an error. I'm just checking for that case.