### PR TITLE
Fixes for calc_shape_dist()

### DIFF
--- a/R/calc_shape_dist.R
+++ b/R/calc_shape_dist.R
@@ -1,73 +1,112 @@
 #' Elastic Shape Distance
 #'
-#' Calculate elastic shape distance between two curves beta1 and beta2. If the
-#' curves beta1 and beta2 are describing multidimensional functional data, then
-#' `rotation == FALSE` and `mode == 'O'`
+#' Calculates the elastic shape distance between two curves `beta1` and `beta2`.
+#' If the input curves are describing multidimensional functional data, then
+#' most of the time the user should set `rotation == FALSE`, `scale == FALSE`
+#' and `mode == "O"`.
 #'
-#' @param beta1 curve1, provided as a matrix of sizes \eqn{n\times T} for
-#'  \eqn{n}-dimensional curve on \eqn{T} sample points
-#' @param beta2 curve 2, provided as a matrix of sizes \eqn{n\times T} for
-#'  \eqn{n}-dimensional curve on \eqn{T} sample points
-#' @param mode Open (`"O"`) or Closed (`"C"`) curves
-#' @param rotation Include rotation (default = `TRUE`)
-#' @param scale scale curves to unit length (default = `TRUE`)
-#' @param include.length include length in distance calculation (default = `FALSE`)
-#'                       this only applies if `scale=TRUE`
-#' @return Returns a list containing \item{d}{geodesic distance}
-#' \item{dx}{phase distance}
-#' \item{q1}{srvf of curve 1}
-#' \item{q2n}{srvf of aligned curve 2}
+#' @param beta1 A numeric matrix of shape \eqn{L \times M} specifying an
+#'   \eqn{L}-dimensional curve evaluated on \eqn{M} sample points.
+#' @param beta2 A numeric matrix of shape \eqn{L \times M} specifying an
+#'   \eqn{L}-dimensional curve evaluated on \eqn{M} sample points. This curve
+#'   will be aligned to `beta1`.
+#' @param mode A character string specifying whether the input curves should be
+#'   considered open (`mode == "O"`) or closed (`mode == "C"`). Defaults to
+#'   `"O"`.
+#' @param rotation A boolean specifying whether the distance should be made
+#'   invariant by rotation. Defaults to `TRUE`.
+#' @param scale A boolean specifying whether the distance should be made
+#'   invariant by scaling. This is effectively achieved by making SRVFs having
+#'   unit length and switching to an appropriate metric on the sphere between
+#'   normalized SRVFs. Defaults to `TRUE`.
+#' @param include.length A boolean specifying whether to include information
+#'   about the actual length of the SRVFs in the metric when using normalized
+#'   SRVFs to achieve scale invariance. This only applies if `scale == TRUE`.
+#'   Defaults to `FALSE`.
+#'
+#' @return A list with the following components:
+#' - `d`: the amplitude (geodesic) distance;
+#' - `dx`: the phase distance;
+#' - `q1`: the SRVF of `beta1`;
+#' - `q2n`: the SRVF of `beta2` after alignment and possible optimal rotation
+#' and scaling;
+#' - `beta1`: the input curve `beta1`;
+#' - `beta2n`: the input curve `beta2` after alignment and possible optimal
+#' rotation and scaling.
+#' - `R`: the optimal rotation matrix that has been applied to the second curve;
+#' - `betascale`: the optimal scaling factor that has been applied to the second
+#' curve;
+#' - `gam`: the optimal warping function that has been applied to the second
+#' curve.
+#'
 #' @keywords distances
+#'
 #' @references Srivastava, A., Klassen, E., Joshi, S., Jermyn, I., (2011). Shape
-#'  analysis of elastic curves in euclidean spaces. Pattern Analysis and Machine
-#'  Intelligence, IEEE Transactions on 33 (7), 1415-1428.
+#'   analysis of elastic curves in euclidean spaces. Pattern Analysis and
+#'   Machine Intelligence, IEEE Transactions on 33 (7), 1415-1428.
 #' @references Kurtek, S., Srivastava, A., Klassen, E., and Ding, Z. (2012),
-#'  “Statistical Modeling of Curves Using Shapes and Related Features,” Journal
-#'  of the American Statistical Association, 107, 1152–1165.
+#'   “Statistical Modeling of Curves Using Shapes and Related Features,” Journal
+#'   of the American Statistical Association, 107, 1152–1165.
+#'
 #' @export
 #' @examples
 #' out <- calc_shape_dist(beta[, , 1, 1], beta[, , 1, 4])
-calc_shape_dist <- function(beta1, beta2, mode="O", rotation=TRUE,
-                            scale=TRUE, include.length=FALSE){
-  T1 = ncol(beta1)
-  centroid1 = calculatecentroid(beta1)
-  dim(centroid1) = c(length(centroid1),1)
-  beta1 = beta1 - repmat(centroid1,1,T1)
-  out1 = curve_to_q(beta1, scale)
-  q1 = out1$q
-  lenq1 = out1$lenq
-  lenq2 = curve_to_q(beta2, scale)$lenq
+calc_shape_dist <- function(beta1, beta2,
+                            mode = "O",
+                            rotation = TRUE,
+                            scale = TRUE,
+                            include.length = FALSE) {
+  T1 <- ncol(beta1)
+  centroid1 <- calculatecentroid(beta1)
+  dim(centroid1) <- c(length(centroid1), 1)
+  beta1 <- beta1 - repmat(centroid1, 1, T1)
+  out1 <- curve_to_q(beta1, scale = scale)
+  q1 <- out1$q
+  lenq1 <- out1$lenq
+  lenq2 <- curve_to_q(beta2, scale = scale)$lenq
 
-  centroid1 = calculatecentroid(beta2)
-  dim(centroid1) = c(length(centroid1),1)
-  beta2 = beta2 - repmat(centroid1,1,T1)
+  centroid1 <- calculatecentroid(beta2)
+  dim(centroid1) <- c(length(centroid1), 1)
+  beta2 <- beta2 - repmat(centroid1, 1, T1)
 
-  out = find_rotation_seed_coord(beta1, beta2, mode, rotation, scale)
-  q1dotq2 = innerprod_q2(q1, out$q2best)
+  out <- find_rotation_seed_coord(
+    beta1, beta2,
+    mode = mode,
+    rotation = rotation,
+    scale = scale
+  )
 
-  if (q1dotq2 > 1){
-    q1dotq2 = 1
-  } else if(q1dotq2 < -1){
-    q1dotq2 = -1
-  }
+  q1dotq2 <- innerprod_q2(q1, out$q2best)
 
-  if (scale){
-    if (include.length){
-      d = sqrt(acos(q1dotq2)^2+log(lenq1/lenq2)^2)
-    } else{
-      d = acos(q1dotq2)
-    }
+  if (q1dotq2 >  1) q1dotq2 <-  1
+  if (q1dotq2 < -1) q1dotq2 <- -1
+
+  if (scale) {
+    if (include.length)
+      d <- sqrt(acos(q1dotq2) ^ 2 + log(lenq1 / lenq2) ^ 2)
+    else
+      d <- acos(q1dotq2)
   } else {
-    v = q1-out$q2best
-    d = sqrt(innerprod_q2(v, v))
+    v <- q1 - out$q2best
+    d <- sqrt(innerprod_q2(v, v))
   }
 
-  gam = out$gambest
-  time1 <- seq(0,1,length.out=T1)
+  gam <- out$gambest
+  time1 <- seq(0, 1, length.out = T1)
   binsize <- mean(diff(time1))
-  psi <- sqrt(gradient(gam,binsize))
-  v <- inv_exp_map(rep(1,length(gam)), psi)
-  dx <- sqrt(trapz(time1, v^2))
+  psi <- sqrt(gradient(gam, binsize))
+  v <- inv_exp_map(rep(1, length(gam)), psi)
+  dx <- sqrt(trapz(time1, v ^ 2))
 
-  return(list(d=d,dx=dx,q1=q1,q2n=out$q2best))
+  list(
+    d = d,
+    dx = dx,
+    q1 = q1,
+    q2n = out$q2best,
+    beta1 = beta1,
+    beta2n = out$beta2best,
+    R = out$Rbest,
+    betascale = out$scale,
+    gam = out$gambest
+  )
 }

--- a/R/curve_pair_align.R
+++ b/R/curve_pair_align.R
@@ -37,9 +37,7 @@ curve_pair_align <- function(beta1, beta2, mode="O", rotation=TRUE, scale=TRUE){
   out = find_rotation_seed_coord(beta1, beta2, mode, rotation, scale)
   gam = out$gambest
   q2n = out$q2best
-  beta2n = out$Rbest %*% shift_f(beta2, out$tau)
-  beta2n = group_action_by_gamma_coord(beta2n, gam)
-  q2n = curve_to_q(beta2n, scale)$q
+  beta2n = out$beta2best
 
   return(list(beta2n=beta2n, q2n=q2n, gam=gam, q1=q1, beta1=beta1, beta2=beta2,
               R=out$Rbest, tau=out$tau))

--- a/man/calc_shape_dist.Rd
+++ b/man/calc_shape_dist.Rd
@@ -14,39 +14,61 @@ calc_shape_dist(
 )
 }
 \arguments{
-\item{beta1}{curve1, provided as a matrix of sizes \eqn{n\times T} for
-\eqn{n}-dimensional curve on \eqn{T} sample points}
+\item{beta1}{A numeric matrix of shape \eqn{L \times M} specifying an
+\eqn{L}-dimensional curve evaluated on \eqn{M} sample points.}
 
-\item{beta2}{curve 2, provided as a matrix of sizes \eqn{n\times T} for
-\eqn{n}-dimensional curve on \eqn{T} sample points}
+\item{beta2}{A numeric matrix of shape \eqn{L \times M} specifying an
+\eqn{L}-dimensional curve evaluated on \eqn{M} sample points. This curve
+will be aligned to \code{beta1}.}
 
-\item{mode}{Open (\code{"O"}) or Closed (\code{"C"}) curves}
+\item{mode}{A character string specifying whether the input curves should be
+considered open (\code{mode == "O"}) or closed (\code{mode == "C"}). Defaults to
+\code{"O"}.}
 
-\item{rotation}{Include rotation (default = \code{TRUE})}
+\item{rotation}{A boolean specifying whether the distance should be made
+invariant by rotation. Defaults to \code{TRUE}.}
 
-\item{scale}{scale curves to unit length (default = \code{TRUE})}
+\item{scale}{A boolean specifying whether the distance should be made
+invariant by scaling. This is effectively achieved by making SRVFs having
+unit length and switching to an appropriate metric on the sphere between
+normalized SRVFs. Defaults to \code{TRUE}.}
 
-\item{include.length}{include length in distance calculation (default = \code{FALSE})
-this only applies if \code{scale=TRUE}}
+\item{include.length}{A boolean specifying whether to include information
+about the actual length of the SRVFs in the metric when using normalized
+SRVFs to achieve scale invariance. This only applies if \code{scale == TRUE}.
+Defaults to \code{FALSE}.}
 }
 \value{
-Returns a list containing \item{d}{geodesic distance}
-\item{dx}{phase distance}
-\item{q1}{srvf of curve 1}
-\item{q2n}{srvf of aligned curve 2}
+A list with the following components:
+\itemize{
+\item \code{d}: the amplitude (geodesic) distance;
+\item \code{dx}: the phase distance;
+\item \code{q1}: the SRVF of \code{beta1};
+\item \code{q2n}: the SRVF of \code{beta2} after alignment and possible optimal rotation
+and scaling;
+\item \code{beta1}: the input curve \code{beta1};
+\item \code{beta2n}: the input curve \code{beta2} after alignment and possible optimal
+rotation and scaling.
+\item \code{R}: the optimal rotation matrix that has been applied to the second curve;
+\item \code{betascale}: the optimal scaling factor that has been applied to the second
+curve;
+\item \code{gam}: the optimal warping function that has been applied to the second
+curve.
+}
 }
 \description{
-Calculate elastic shape distance between two curves beta1 and beta2. If the
-curves beta1 and beta2 are describing multidimensional functional data, then
-\code{rotation == FALSE} and \code{mode == 'O'}
+Calculates the elastic shape distance between two curves \code{beta1} and \code{beta2}.
+If the input curves are describing multidimensional functional data, then
+most of the time the user should set \code{rotation == FALSE}, \code{scale == FALSE}
+and \code{mode == "O"}.
 }
 \examples{
 out <- calc_shape_dist(beta[, , 1, 1], beta[, , 1, 4])
 }
 \references{
 Srivastava, A., Klassen, E., Joshi, S., Jermyn, I., (2011). Shape
-analysis of elastic curves in euclidean spaces. Pattern Analysis and Machine
-Intelligence, IEEE Transactions on 33 (7), 1415-1428.
+analysis of elastic curves in euclidean spaces. Pattern Analysis and
+Machine Intelligence, IEEE Transactions on 33 (7), 1415-1428.
 
 Kurtek, S., Srivastava, A., Klassen, E., and Ding, Z. (2012),
 “Statistical Modeling of Curves Using Shapes and Related Features,” Journal


### PR DESCRIPTION
I found a couple of issues in `find_rotation_seed_coord()` that had repercussions on `calc_shape_dist()`. The latter now performs the same calculations as in `curve_pair_align()`. In particular, the object `beta2best` output by `find_rotation_seed_coord()` is properly rotated and scaled when `rotation == TRUE` and `scale == TRUE` which makes it directly useable in `calc_shape_dist()` and `curve_pair_align()` without the need to perform the rotation, scaling and group action again a posteriori.

`calc_shape_dist()` is also better documented and its output has been augmented. 

- I have not renamed already existing output components in order not to break existing code that uses the function, although I think that `d` and `dx` for amplitude and phase distances could have better names.
- I added `betascale` which is intended to be the optimal scaling factor that has been applied to the second curve when `scale == TRUE`; it is nothing but the length of `beta1` divided by the length of `beta2`;
- we could output `qscale` as well but it is not currently the case.

Lastly, I feel that we should document that the output `beta1` is slightly different from the input of the same name. by clarifying what the centring performed via `calculatecentroid()` does.
