### PR TITLE
Improved distance (matrix) computation

### DIFF
--- a/R/calc_shape_dist.R
+++ b/R/calc_shape_dist.R
@@ -36,9 +36,9 @@
 #' - `beta2n`: the input curve `beta2` after alignment and possible optimal
 #' rotation and scaling.
 #' - `R`: the optimal rotation matrix that has been applied to the second curve;
-#' - `betascale`: the optimal scaling factor that has been applied to the second
-#' curve;
 #' - `gam`: the optimal warping function that has been applied to the second
+#' curve;
+#' - `betascale`: the optimal scaling factor that has been applied to the second
 #' curve.
 #'
 #' @keywords distances
@@ -62,47 +62,23 @@ calc_shape_dist <- function(beta1, beta2,
   srvf1 <- curve_to_srvf(beta1, scale = scale)
   srvf2 <- curve_to_srvf(beta2, scale = scale)
 
-  out <- find_rotation_seed_unique(
-    srvf1$q, srvf2$q,
+  out <- match_f2_to_f1(
+    srvf1, srvf2, beta2,
     mode = mode,
     alignment = alignment,
     rotation = rotation,
     scale = scale
   )
 
-  # Compute amplitude distance
-  d <- out$d
-
-  # Compute phase distance
-  gam <- out$gambest
-  dx <- phase_distance(gam)
-
-  # Compute beta2n
-  qscale <- 1
-  if (scale)
-    qscale <- srvf1$qnorm / srvf2$qnorm
-  betascale <- qscale^2
-
-  if (mode == "C") {
-    beta2n <- q_to_curve(out$q2best, scale = qscale)
-  } else {
-    beta2n <- beta2 - srvf2$centroid
-    beta2n <- out$Rbest %*% beta2n
-    beta2n <- group_action_by_gamma_coord(beta2n, gam)
-    beta2n <- beta2n * betascale
-  }
-  beta2n <- beta2n + srvf1$centroid
-
-  # Return results
   list(
-    d = d,
-    dx = dx,
+    d = out$d,
+    dx = out$dx,
     q1 = srvf1$q,
-    q2n = out$q2best,
+    q2n = out$q2n,
     beta1 = beta1,
-    beta2n = beta2n,
+    beta2n = out$beta2n,
     R = out$Rbest,
-    betascale = betascale,
-    gam = gam
+    gam = out$gambest,
+    betascale = out$betascale
   )
 }

--- a/R/curve_dist.R
+++ b/R/curve_dist.R
@@ -58,11 +58,11 @@ curve_dist <- function(beta,
     j <- k + i + 1 - N * (N - 1) / 2 + (N - i) * ((N - i) - 1) / 2
 
     # Increment indices as previous ones are 0-based while R expects 1-based
-    beta1 <- beta[, , i + 1]
-    beta2 <- beta[, , j + 1]
+    q1 <- beta[, , i + 1]
+    q2 <- beta[, , j + 1]
 
     out <- find_rotation_seed_unique(
-      beta1, beta2,
+      q1, q2,
       mode = mode,
       alignment = alignment,
       rotation = rotation,

--- a/R/curve_functions.R
+++ b/R/curve_functions.R
@@ -18,13 +18,10 @@ calculatecentroid <- function(beta,returnlength = F){
   return(centroid)
 }
 
-
-innerprod_q2 <- function(q1, q2){
-    T1 = ncol(q1)
-    val = sum(q1*q2)/T1
-    return(val)
+innerprod_q2 <- function(q1, q2) {
+  T1 <- ncol(q1)
+  sum(q1 * q2) / T1
 }
-
 
 find_best_rotation <- function(q1, q2){
     eps = .Machine$double.eps
@@ -175,7 +172,7 @@ find_rotation_seed_coord <- function(beta1, beta2,
 
   for (ctr in 0:end_idx) {
     if (mode == "C") {
-      if ((scl*ctr) <= end_idx)
+      if (scl * ctr <= end_idx)
         beta2n <- shift_f(beta2, scl * ctr)
       else
         break
@@ -311,12 +308,17 @@ find_rotation_seed_unique <- function(q1, q2,
         q2best <- q2new
         gambest <- gam
         minE <- Ec
+        tau <- scl * ctr
       }
     }
 
-    list(q2best = q2best, Rbest = Rbest, gambest = gambest)
+    list(
+      q2best = q2best,
+      Rbest = Rbest,
+      gambest = gambest,
+      tau = tau
+    )
 }
-
 
 find_rotation_and_seed_q <- function(q1,q2){
     n = nrow(q1)

--- a/R/curve_functions.R
+++ b/R/curve_functions.R
@@ -158,7 +158,8 @@ shift_f <- function(f, tau){
 find_rotation_seed_coord <- function(beta1, beta2,
                                      mode = "O",
                                      rotation = TRUE,
-                                     scale = TRUE) {
+                                     scale = TRUE,
+                                     lambda = 0.0) {
   n <- nrow(beta1)
   T1 <- ncol(beta1)
   out <- curve_to_q(beta1, scale = scale)
@@ -197,7 +198,8 @@ find_rotation_seed_coord <- function(beta1, beta2,
       q2ni <- q2n / sqrt(innerprod_q2(q2n, q2n))
       dim(q1i) <- c(T1 * n)
       dim(q2ni) <- c(T1 * n)
-      gam0 <- .Call('DPQ', PACKAGE = 'fdasrvf', q1i, q2ni, n, T1, 0, 1, 0, rep(0,T1))
+      gam0 <- .Call('DPQ', PACKAGE = 'fdasrvf', q1i, q2ni,
+                    n, T1, lambda, 1, 0, rep(0,T1))
       gamI <- invertGamma(gam0)
       gam <- (gamI - gamI[1]) / (gamI[length(gamI)] - gamI[1])
       beta2new <- group_action_by_gamma_coord(beta2n, gam)
@@ -250,7 +252,7 @@ find_rotation_seed_unique <- function(q1, q2,
                                       mode = "O",
                                       rotation = TRUE,
                                       scale = TRUE,
-                                      lam = 0.0) {
+                                      lambda = 0.0) {
     n1 <- nrow(q1)
     T1 <- ncol(q1)
     scl <- 4
@@ -280,7 +282,7 @@ find_rotation_seed_unique <- function(q1, q2,
         dim(q1i) <- c(T1 * n1)
         dim(q2ni) <- c(T1 * n1)
         gam0 <- .Call('DPQ', PACKAGE = 'fdasrvf', q1i, q2ni,
-                      n1, T1, lam, 1, 0, rep(0, T1))
+                      n1, T1, lambda, 1, 0, rep(0, T1))
         gamI <- invertGamma(gam0)
         gam <- (gamI - gamI[1]) / (gamI[length(gamI)] - gamI[1])
         beta2n <- q_to_curve(q2n)
@@ -289,8 +291,7 @@ find_rotation_seed_unique <- function(q1, q2,
 
         if (mode == "C")
           q2new <- project_curve(q2new)
-      }
-      else {
+      } else {
         q2new <- q2n
         gam <- seq(0, 1, length.out = T1)
       }
@@ -642,7 +643,7 @@ karcher_calc <- function(q1, mu, basis,
       mode = mode,
       rotation = rotated,
       scale = TRUE,
-      lam = lambda
+      lambda = lambda
     )
 
     qn_t <- out$q2best / sqrt(innerprod_q2(out$q2best, out$q2best))

--- a/R/curve_functions.R
+++ b/R/curve_functions.R
@@ -716,3 +716,50 @@ curve_to_srvf <- function(beta, scale = TRUE) {
   out <- curve_to_q(beta, scale = scale)
   list(q = out$q, qnorm = out$lenq, centroid = centroid)
 }
+
+match_f2_to_f1 <- function(srvf1, srvf2, beta2,
+                           mode = "O",
+                           alignment = TRUE,
+                           rotation = FALSE,
+                           scale = FALSE) {
+  out <- find_rotation_seed_unique(
+    srvf1$q, srvf2$q,
+    mode = mode,
+    alignment = alignment,
+    rotation = rotation,
+    scale = scale
+  )
+
+  # Compute amplitude distance
+  d <- out$d
+
+  # Compute phase distance
+  gam <- out$gambest
+  dx <- phase_distance(gam)
+
+  # Compute beta2n
+  qscale <- 1
+  if (scale)
+    qscale <- srvf1$qnorm / srvf2$qnorm
+  betascale <- qscale^2
+
+  if (mode == "C") {
+    beta2n <- q_to_curve(out$q2best, scale = qscale)
+  } else {
+    beta2n <- beta2 - srvf2$centroid
+    beta2n <- out$Rbest %*% beta2n
+    beta2n <- group_action_by_gamma_coord(beta2n, gam)
+    beta2n <- beta2n * betascale
+  }
+  beta2n <- beta2n + srvf1$centroid
+
+  list(
+    d = d,
+    dx = dx,
+    q2n = out$q2best,
+    beta2n = beta2n,
+    betascale = betascale,
+    Rbest = out$Rbest,
+    gambest = gam
+  )
+}

--- a/R/curve_karcher_cov.R
+++ b/R/curve_karcher_cov.R
@@ -10,7 +10,7 @@
 #' @references Srivastava, A., Klassen, E., Joshi, S., Jermyn, I., (2011). Shape analysis of elastic curves in euclidean spaces. Pattern Analysis and Machine Intelligence, IEEE Transactions on 33 (7), 1415-1428.
 #' @export
 #' @examples
-#' out <- curve_karcher_mean(beta[, , 1, 1:2], maxit = 2, parallel=FALSE)
+#' out <- curve_karcher_mean(beta[, , 1, 1:2], maxit = 2)
 #' # note: use more shapes, small for speed
 #' K <- curve_karcher_cov(out$v)
 curve_karcher_cov <- function(v, len = NA){

--- a/R/curve_karcher_mean.R
+++ b/R/curve_karcher_mean.R
@@ -73,7 +73,7 @@ curve_karcher_mean <- function(beta,
                                lambda = 0.0,
                                maxit = 20,
                                ms = c("mean", "median"),
-                               parallel = TRUE)
+                               ncores = 1L)
 {
   navail <- max(parallel::detectCores() - 1, 1)
 

--- a/R/curve_karcher_mean.R
+++ b/R/curve_karcher_mean.R
@@ -1,190 +1,254 @@
 #' Karcher Mean of Curves
 #'
 #' Calculates Karcher mean or median of a collection of curves using the elastic
-#' square-root velocity (srvf) framework.
+#' square-root velocity (SRVF) framework.
 #'
-#' @param beta Array of sizes \eqn{n \times T \times N} describing \eqn{N}
-#' curves of dimension \eqn{n} evaluated on \eqn{T} points
-#' @param mode Open (`"O"`) or Closed (`"C"`) curves
-#' @param rotated Optimize over rotation (default = `TRUE`)
-#' @param scale scale curves to unit length (default = `TRUE`)
+#' @param beta A numeric array of shape \eqn{L \times M \times N} specifying an
+#'   \eqn{N}-sample of \eqn{L}-dimensional curves evaluated on \eqn{M} points.
+#' @inheritParams calc_shape_dist
+#' @param rotated A boolean specifying whether to make the metric
+#'   rotation-invariant. Defaults to `FALSE`.
 #' @param lambda A numeric value specifying the elasticity. Defaults to `0.0`.
-#' @param maxit maximum number of iterations
-#' @param ms string defining whether the Karcher mean (`"mean"`) or Karcher
-#' median (`"median"`) is returned (default = `"mean"`)
-#' @param parallel A boolean specifying whether to run calculations in parallel.
-#'   Defaults to `TRUE`.
+#' @param maxit An integer value specifying the maximum number of iterations.
+#'   Defaults to `20L`.
+#' @param ms A character string specifying whether the Karcher mean ("mean") or
+#'   Karcher median ("median") is returned. Defaults to `"mean"`.
+#' @param ncores An integer value specifying the number of cores to use for
+#'   parallel computation. Defaults to `1L`. The maximum number of available
+#'   cores is determined by the **parallel** package. One core is always left
+#'   out to avoid overloading the system.
+#'
 #' @return An object of class `fdacurve` which is a list with the following
 #'   components:
-#' - `mu`: mean srvf
-#' - `beta`: centered curves
-#' - `betamean`: mean or median curve
-#' - `type`: string indicating whether mean or median is returned
-#' - `v`: shooting vectors
-#' - `q`: array of srvfs
-#' - `gam`: array of warping functions
-#' - `cent`: centers of original curves
-#' - `len`: length of curves
-#' - `len_q`: length of srvfs
-#' - `mean_scale`: mean length
-#' - `mean_scale_q`: mean length srvf
-#' - `E`: energy
-#' - `qun`: cost function
+#'   - beta: A numeric array of shape \eqn{L \times M \times N} specifying the
+#'   \eqn{N}-sample of \eqn{L}-dimensional curves evaluated on \eqn{M} points.
+#'   The curves might be slightly different from the input curves as they have
+#'   been centered.
+#'   - `mu`: A numeric array of shape \eqn{L \times M} specifying the Karcher
+#'   mean or median of the SRVFs of the input curves.
+#'   - `type`: A character string specifying whether the Karcher mean or median
+#'   is returned.
+#'   - `betamean`: A numeric array of shape \eqn{L \times M} specifying the
+#'   Karcher mean or median of the input curves.
+#'   - `v`: A numeric array of shape \eqn{L \times M \times N} specifying the
+#'   shooting vectors.
+#'   - `q`: A numeric array of shape \eqn{L \times M \times N} specifying the
+#'   SRVFs of the input curves.
+#'   - `E`: A numeric vector of shape \eqn{N} specifying XXX (TO DO)
+#'   - `cent`: A numeric array of shape \eqn{L \times M} specifying the centers
+#'   of the input curves.
+#'   - `len`: A numeric vector of shape \eqn{N} specifying the length of the
+#'   input curves.
+#'   - `len_q`: A numeric vector of shape \eqn{N} specifying the length of the
+#'   SRVFs of the input curves.
+#'   - `qun`: A numeric vector of shape \eqn{maxit} specifying the consecutive
+#'   values of the cost function.
+#'   - `mean_scale`: A numeric value specifying the mean length of the input
+#'   curves.
+#'   - `mean_scale_q`: A numeric value specifying the mean length of the SRVFs
+#'   of the input curves.
+#'   - `mode`: A character string specifying the mode of the input curves.
+#'   - `rotated`: A boolean specifying whether the metric is rotation-invariant.
+#'   - `scale`: A boolean specifying whether the metric is scale-invariant.
+#'   - `ms`: A character string specifying whether the Karcher mean or median is
+#'   returned.
+#'   - `lambda`: A numeric value specifying the elasticity ??? (TO DO).
+#'   - `rsamps`: ??? (TO DO).
+#'
 #' @keywords srvf alignment
+#'
 #' @references Srivastava, A., Klassen, E., Joshi, S., Jermyn, I., (2011). Shape
-#'    analysis of elastic curves in euclidean spaces. Pattern Analysis and Machine
-#'    Intelligence, IEEE Transactions on 33 (7), 1415-1428.
+#'   analysis of elastic curves in Euclidean spaces. Pattern Analysis and
+#'   Machine Intelligence, IEEE Transactions on 33 (7), 1415-1428.
+#'
 #' @export
+#'
 #' @examples
-#' out <- curve_karcher_mean(beta[, , 1, 1:2], maxit = 2, parallel=FALSE)
+#' out <- curve_karcher_mean(beta[, , 1, 1:2], maxit = 2)
 #' # note: use more shapes, small for speed
-curve_karcher_mean <- function (beta, mode = "O", rotated = TRUE, scale = TRUE,
-                                lambda = 0.0, maxit = 20, ms = "mean",
-                                parallel = TRUE)
+curve_karcher_mean <- function(beta,
+                               mode = "O",
+                               rotated = TRUE,
+                               scale = TRUE,
+                               lambda = 0.0,
+                               maxit = 20,
+                               ms = c("mean", "median"),
+                               parallel = TRUE)
 {
+  navail <- max(parallel::detectCores() - 1, 1)
 
-  if (parallel) {
-    cores <- max(parallel::detectCores() - 1, 1)
-    cl <- parallel::makeCluster(cores)
+  if (ncores > navail) {
+    cli::cli_alert_warning(
+      "The number of requested cores ({ncores}) is larger than the number of
+      available cores ({navail}). Using the maximum number of available cores..."
+    )
+    ncores <- navail
+  }
+
+  if (ncores > 1L) {
+    cl <- parallel::makeCluster(ncores)
     doParallel::registerDoParallel(cl)
+    on.exit(parallel::stopCluster(cl))
   } else
     foreach::registerDoSEQ()
 
-  if(ms!="mean"&ms!="median"){warning("ms must be either \"mean\" or \"median\". ms has been set to \"mean\"",immediate. = T)}
-  if(ms!="median"){ms = "mean"}
+  ms <- rlang::arg_match(ms)
 
-  mean_scale = NA
-  mean_scale_q = NA
-  tmp = dim(beta)
-  n = tmp[1]
-  T1 = tmp[2]
-  N = tmp[3]
-  q = array(0, c(n, T1, N))
-  len = rep(0, N)
-  len_q = rep(0, N)
-  cent = matrix(0, n, N)
-  for (ii in 1:N) {
-    beta1 = beta[ , , ii]
-    centroid1 = calculatecentroid(beta1)
-    cent[ , ii] = -1 * centroid1
-    dim(centroid1) = c(length(centroid1), 1)
-    beta1 = beta1 - repmat(centroid1, 1, T1)
-    beta[ , , ii] = beta1
-    out = curve_to_q(beta1)
-    q[, , ii] = out$q
-    len[ii] = out$len
-    len_q[ii] = out$lenq
+  mean_scale <- NA
+  mean_scale_q <- NA
+  dims <- dim(beta)
+  L <- dims[1]
+  M <- dims[2]
+  N <- dims[3]
+  q <- array(0, dim = c(L, M, N))
+  len <- rep(0, N)
+  len_q <- rep(0, N)
+  cent <- matrix(0, nrow = L, ncol = N)
+
+  for (n in 1:N) {
+    beta1 <- beta[ , , n]
+    centroid1 <- calculatecentroid(beta1)
+    cent[, n] <- -1 * centroid1
+    dim(centroid1) <- c(length(centroid1), 1)
+    beta1 <- beta1 - repmat(centroid1, 1, M)
+    beta[ , , n] <- beta1
+    out <- curve_to_q(beta1, scale = TRUE)
+    q[, , n] <- out$q
+    len[n] <- out$len
+    len_q[n] <- out$lenq
   }
 
-  mu = q[, , 1]
-  bmu = beta[, , 1]
-  delta = 0.5
-  tolv = 1e-04
-  told = 5 * 0.001
-  itr = 1
-  sumd = rep(0, maxit + 1)
-  sumd[1] = Inf
-  v = array(0, c(n, T1, N))
-  normvbar = rep(0, maxit + 1)
-  if(ms == "median"){ #run for median only, saves memory if getting mean
-    d_i = rep(0,N) #include vector for norm calculations
-    v_d = array(0, c(n, T1, N)) #include array to hold v_i / d_i
+  mu <- q[, , 1]
+  bmu <- beta[, , 1]
+  delta <- 0.5
+  tolv <- 1e-04
+  told <- 5 * 0.001
+  itr <- 1L
+  sumd <- rep(0, maxit + 1)
+  sumd[1] <- Inf
+  v <- array(0, dim = c(L, M, N))
+  normvbar <- rep(0, maxit + 1)
+
+  if (ms == "median") {
+    # run for median only, saves memory if getting mean
+    d_i <- rep(0, N) # include vector for norm calculations
+    v_d <- array(0, dim = c(L, M, N)) # include array to hold v_i / d_i
   }
 
-
-  cat("\nInitializing...\n")
+  cli::cli_alert_info("Initializing...")
   gam <- foreach::foreach(n = 1:N, .combine = cbind, .packages = "fdasrvf") %dopar% {
-    gam_tmp <- find_rotation_seed_unqiue(mu, q[, , n], mode, rotated, TRUE, lambda)$gambest
+    find_rotation_seed_unique(
+      q1 = mu,
+      q2 = q[, , n],
+      mode = mode,
+      rotation = rotated,
+      scale = TRUE,
+      lambda = lambda
+    )$gambest
   }
 
-  gam = t(gam)
-  gamI = SqrtMeanInverse(t(gam))
-  bmu = group_action_by_gamma_coord(bmu, gamI)
-  mu = curve_to_q(bmu)$q
+  gamI <- SqrtMeanInverse(gam)
+  bmu <- group_action_by_gamma_coord(bmu, gamI)
+  mu <- curve_to_q(bmu)$q
   mu[is.nan(mu)] <- 0
 
   while (itr < maxit) {
-    cat(sprintf("Iteration: %d\n", itr))
-    mu = mu/sqrt(innerprod_q2(mu, mu))
+    cli::cli_alert_info("Iteration {itr}/{maxit}...")
 
-    if (mode=="C"){
-      basis = find_basis_normal(mu)
-    }
+    mu <- mu / sqrt(innerprod_q2(mu, mu))
+
+    if (mode == "C") basis <- find_basis_normal(mu)
 
     outfor <- foreach::foreach(n = 1:N, .combine = cbind, .packages='fdasrvf') %dopar% {
-      out <- karcher_calc(q[, , n], mu, basis, rotated, mode, lambda, ms)
-      v <- out$v
-      v_d <- out$v_d
-      dist <- out$dist
-      d_i <- out$d_i
-
-      list(v, v_d, dist, d_i)
+      out <- karcher_calc(
+        q1 = q[, , n],
+        mu = mu,
+        basis = basis,
+        rotated = rotated,
+        mode = mode,
+        lambda = lambda,
+        ms = ms
+      )
+      list(out$v, out$v_d, out$dist, out$d_i)
     }
 
     v <- unlist(outfor[1, ])
-    dim(v) <- c(n, T1, N)
+    dim(v) <- c(L, M, N)
 
     v_d <- unlist(outfor[2, ])
-    dim(v_d) <- c(n, T1, N)
+    dim(v_d) <- c(L, M, N)
 
     dist <- unlist(outfor[3, ])
-    dim(dist) <- c(N)
+    dim(dist) <- N
 
     d_i <- unlist(outfor[4, ])
-    dim(d_i) <- c(N)
+    dim(d_i) <- N
 
     sumd[itr + 1] = sumd[itr + 1] + sum(dist^2)
 
-    if(ms == "median"){#run for median only
-      sumv = rowSums(v_d, dims = 2)
-      sum_dinv = sum(1/d_i)
-      vbar = sumv/sum_dinv
-    }
-    else{ #run for mean only
-      sumv = rowSums(v, dims = 2)
-      vbar = sumv/N
+    if (ms == "median") {
+      # run for median only
+      sumv <- rowSums(v_d, dims = 2)
+      sum_dinv <- sum(1 / d_i)
+      vbar <- sumv / sum_dinv
+    } else {
+      # run for mean only
+      sumv <- rowSums(v, dims = 2)
+      vbar <- sumv / N
     }
 
-    normvbar[itr] = sqrt(innerprod_q2(vbar, vbar))
-    normv = normvbar[itr]
-    if ((sumd[itr]-sumd[itr+1]) < 0){
+    normvbar[itr] <- sqrt(innerprod_q2(vbar, vbar))
+    normv <- normvbar[itr]
+
+    if ((sumd[itr] - sumd[itr + 1]) < 0 ||
+        normv <= tolv ||
+        abs(sumd[itr + 1] - sumd[itr]) < told)
       break
-    } else if ((normv > tolv) && (abs(sumd[itr + 1] - sumd[itr]) > told)) {
-      mu = cos(delta * normvbar[itr]) * mu + sin(delta *
-                                                   normvbar[itr]) * vbar/normvbar[itr]
-      if (mode == "C") {
-        mu = project_curve(mu)
-      }
-      x = q_to_curve(mu)
-      a = -1 * calculatecentroid(x)
-      dim(a) = c(length(a), 1)
-      betamean = x + repmat(a, 1, T1)
-    }
-    else {
-      break
-    }
-    itr = itr + 1
+
+    mu <- cos(delta * normvbar[itr]) * mu +
+      sin(delta * normvbar[itr]) * vbar / normvbar[itr]
+    if (mode == "C") mu <- project_curve(mu)
+    x <- q_to_curve(mu)
+    a <- -1 * calculatecentroid(x)
+    dim(a) <- c(length(a), 1)
+    betamean <- x + repmat(a, 1, M)
+
+    itr <- itr + 1L
   }
 
-  if (!scale){
-    mean_scale = prod(len)^(1/length(len))
-    mean_scale_q = prod(len_q)^(1/length(len))
-    x = q_to_curve(mu, mean_scale_q)
-    a = -1 * calculatecentroid(x)
-    dim(a) = c(length(a), 1)
-    betamean = x + repmat(a, 1, T1)
-    mu = curve_to_q(betamean, scale)$q
+  if (!scale) {
+    mean_scale <- prod(len) ^ (1 / length(len))
+    mean_scale_q <- prod(len_q) ^ (1 / length(len))
+    x <- q_to_curve(mu, mean_scale_q)
+    a <- -1 * calculatecentroid(x)
+    dim(a) <- c(length(a), 1)
+    betamean <- x + repmat(a, 1, M)
+    mu <- curve_to_q(betamean, scale)$q
   }
 
-  if (parallel) parallel::stopCluster(cl)
+  type <- ifelse(ms == "median", "Karcher Median", "Karcher Mean")
 
-  ifelse(ms=="median",type<-"Karcher Median",type<-"Karcher Mean")
-
-  out <- list(beta = beta, mu = mu, type = type, betamean = betamean, v = v, q = q,
-              E=normvbar[1:itr], cent = cent, len = len, len_q = len_q,
-              qun = sumd[1:itr], mean_scale = mean_scale, mean_scale_q=mean_scale_q,
-              mode=mode, rotated=rotated, scale=scale, ms=ms, lambda=lambda,
-              rsamps=FALSE)
+  out <- list(
+    beta = beta,
+    mu = mu,
+    type = type,
+    betamean = betamean,
+    v = v,
+    q = q,
+    E = normvbar[1:itr],
+    cent = cent,
+    len = len,
+    len_q = len_q,
+    qun = sumd[1:itr],
+    mean_scale = mean_scale,
+    mean_scale_q = mean_scale_q,
+    mode = mode,
+    rotated = rotated,
+    scale = scale,
+    ms = ms,
+    lambda = lambda,
+    rsamps = FALSE
+  )
 
   class(out) <- "fdacurve"
   return(out)

--- a/R/curve_principal_directions.R
+++ b/R/curve_principal_directions.R
@@ -18,7 +18,7 @@
 #' @references Srivastava, A., Klassen, E., Joshi, S., Jermyn, I., (2011). Shape analysis of elastic curves in euclidean spaces. Pattern Analysis and Machine Intelligence, IEEE Transactions on 33 (7), 1415-1428.
 #' @export
 #' @examples
-#' out <- curve_karcher_mean(beta[, , 1, 1:2], maxit = 2, parallel=FALSE)
+#' out <- curve_karcher_mean(beta[, , 1, 1:2], maxit = 2)
 #' # note: use more shapes, small for speed
 #' K <- curve_karcher_cov(out$v)
 #' out <- curve_principal_directions(out$v, K, out$mu)

--- a/R/kmeans.R
+++ b/R/kmeans.R
@@ -193,7 +193,7 @@ kmeans_align <- function(f, time,
       outfor <- foreach::foreach(n = 1:N, .combine = cbind, .packages = "fdasrvf") %dopar% {
         if (alignment) {
           if (L > 1){
-            out = find_rotation_seed_unqiue(templates.q[, , k], q[, , n],
+            out = find_rotation_seed_unique(templates.q[, , k], q[, , n],
                                             mode='O', rotation=rotation, scale=scale)
             gam_tmp = out$gambest
 

--- a/R/kmeans.R
+++ b/R/kmeans.R
@@ -175,11 +175,7 @@ kmeans_align <- function(f, time,
 
   templates.q <- array(0, dim = c(L, M, K))
   for (k in 1:K)
-  {
-    print(template.ind[k])
     templates.q[, , k] <- q[, , template.ind[k]]
-  }
-
 
   # For storing final distances to center
   dtc <- rep(NA, N)

--- a/R/kmeans.R
+++ b/R/kmeans.R
@@ -165,15 +165,21 @@ kmeans_align <- function(f, time,
       f[l, , ] <- smooth.data(f[l, , ], sparam = sparam)
   }
 
-  if (L > 1){
-    q <- curve_to_q(f, scale)
+  if (L > 1) {
+    q <- array(dim = c(L, M, N))
+    for (n in 1:N)
+      q[, , n] <- curve_to_q(f[, , n], scale)$q
   } else {
     q <- f_to_srvf(f, time)
   }
 
   templates.q <- array(0, dim = c(L, M, K))
   for (k in 1:K)
+  {
+    print(template.ind[k])
     templates.q[, , k] <- q[, , template.ind[k]]
+  }
+
 
   # For storing final distances to center
   dtc <- rep(NA, N)
@@ -214,7 +220,7 @@ kmeans_align <- function(f, time,
 
         if (L > 1){
           fw <- group_action_by_gamma_coord(f[, , n], gam_tmp)
-          qw <- curve_to_q(fw, scale)
+          qw <- curve_to_q(fw, scale)$q
         } else {
           fw <- warp_f_gamma(f[1, , n], time, gam_tmp)
           qw <- f_to_srvf(fw, time)
@@ -293,7 +299,7 @@ kmeans_align <- function(f, time,
 
         if (L > 1){
           fw <- group_action_by_gamma_coord(ftmp[, , n], gamI)
-          qw <- curve_to_q(fw, scale)
+          qw <- curve_to_q(fw, scale)$q
         } else {
           fw <- warp_f_gamma(ftmp[1, , n], time, gamI)
           qw <- f_to_srvf(fw, time)
@@ -328,27 +334,27 @@ kmeans_align <- function(f, time,
         next()
       }
 
-      if (L > 1){
-        if (scale == FALSE){
+      if (L > 1) {
+        if (!scale) {
           if (centroid_type == "mean") {
-            out <- multivariate_karcher_mean(fn[[k]][l, , id])
-            templates[1, , k] <- out$betamean
-            templates.q[1, , k] <- curve_to_q(out$betamean, scale)
+            out <- multivariate_karcher_mean(fn[[k]][, , id])
+            templates[, , k] <- out$betamean
+            templates.q[, , k] <- curve_to_q(out$betamean, scale)$q
           } else if (centroid_type == "medoid") {
-            out <- multivariate_karcher_mean(fn[[k]][l, , id], ms='median')
-            templates.q[1, , k] <- out$betamean
-            templates[1, , k] <- curve_to_q(out$betamean, scale)
+            out <- multivariate_karcher_mean(fn[[k]][, , id], ms='median')
+            templates.q[, , k] <- out$betamean
+            templates[, , k] <- curve_to_q(out$betamean, scale)$q
           }
         } else {
           if (centroid_type == "mean") {
-            out = curve_karcher_mean(fn[[k]][l, , id], mode = "O", rotated = rotation)
-            templates[1, , k] <- out$betamean
-            templates.q[1, , k] <- curve_to_q(out$betamean, scale)
+            out = curve_karcher_mean(fn[[k]][, , id], mode = "O", rotated = rotation)
+            templates[, , k] <- out$betamean
+            templates.q[, , k] <- curve_to_q(out$betamean, scale)$q
           } else if (centroid_type == "medoid") {
-            out = curve_karcher_mean(fn[[k]][l, , id], mode = "O", rotated = rotation,
+            out = curve_karcher_mean(fn[[k]][, , id], mode = "O", rotated = rotation,
                                      ms='median')
-            templates[1, , k] <- out$betamean
-            templates.q[1, , k] <- curve_to_q(out$betamean, scale)
+            templates[, , k] <- out$betamean
+            templates.q[, , k] <- curve_to_q(out$betamean, scale)$q
           }
         }
       } else {

--- a/R/multivariate_karcher_mean.R
+++ b/R/multivariate_karcher_mean.R
@@ -14,6 +14,7 @@
 #' @param scale A boolean specifying whether to make the metric scale-invariant.
 #'   Defaults to `FALSE`.
 #' @param maxit An integer value specifying the maximum number of iterations.
+#'   Defaults to `20L`.
 #' @param ms A character string specifying whether the Karcher mean ("mean") or
 #'   Karcher median ("median") is returned. Defaults to `"mean"`.
 #' @param ncores An integer value specifying the number of cores to use for
@@ -55,7 +56,7 @@
 multivariate_karcher_mean <- function(beta,
                                       rotation = FALSE,
                                       scale = FALSE,
-                                      maxit = 20,
+                                      maxit = 20L,
                                       ms = c("mean", "median"),
                                       ncores = 1L)
 {

--- a/R/utils-pointwise.R
+++ b/R/utils-pointwise.R
@@ -1,0 +1,88 @@
+amplitude_distance <- function(q1, q2, scale = FALSE, norm_ratio = 1) {
+  if (scale) {
+    q1dotq2 <- innerprod_q2(q1, q2)
+    if (q1dotq2 >  1) q1dotq2 <-  1
+    if (q1dotq2 < -1) q1dotq2 <- -1
+    d <- sqrt(acos(q1dotq2) ^ 2 + log(norm_ratio) ^ 2)
+  } else {
+    v <- q1 - q2
+    d <- sqrt(innerprod_q2(v, v))
+  }
+  d
+}
+
+phase_distance <- function(gam) {
+  M <- length(gam)
+  grd <- seq(0, 1, length.out = M)
+  binsize <- mean(diff(grd))
+  psi <- sqrt(gradient(gam, binsize))
+  v <- inv_exp_map(rep(1, M), psi)
+  sqrt(trapz(grd, v ^ 2))
+}
+
+pointwise_mean <- function(q, beta, qmean,
+                           basis = NULL,
+                           scale = FALSE,
+                           ms = "mean") {
+  dims <- dim(q)
+  L <- dims[1]
+  M <- dims[2]
+  N <- dims[3]
+
+  if (!scale) {
+    # SVRF space has L2 geometry
+    qmean <- rowMeans(q, dims = 2)
+    betamean <- q_to_curve(qmean) + rowMeans(beta[, 1, ])
+  } else {
+    # SVRF space has L2 hypersphere geometry
+    v <- v_d <- array(dim = c(L, M, N))
+    d_i <- numeric(N)
+    for (n in 1:N) {
+      work_q <- q[, , n]
+      q1dotq2 <- innerprod_q2(qmean, work_q)
+      if (q1dotq2 >  1) q1dotq2 <-  1
+      if (q1dotq2 < -1) q1dotq2 <- -1
+      u <- work_q - q1dotq2 * qmean
+      normu <- sqrt(innerprod_q2(u, u))
+      if (normu > 1e-4)
+        w <- u * acos(q1dotq2) / normu
+      else
+        w <- matrix(0, L, M)
+
+      if (is.null(basis))
+        v[, , n] <- w
+      else
+        v[, , n] <- project_tangent(w, qmean, basis)
+
+      d_i[n] <- 0
+      if (ms == "median") {
+        # run for median only, saves computation time if getting mean
+        d_i[n] <- sqrt(innerprod_q2(v[, , n], v[, , n])) # calculate sqrt of norm of v_i
+        if (d_i[n] > 0)
+          v_d[, , n] <- v[, , n] / d_i[n] # normalize v_i
+        else
+          v_d[, , n] <- v[, , n]
+      } else
+        v_d[, , n] <- matrix(0, nrow = L, ncol = M)
+    }
+
+    if (ms == "median") {
+      # run for median only
+      sumv <- rowSums(v_d, dims = 2)
+      sum_dinv <- sum(1 / d_i)
+      vbar <- sumv / sum_dinv
+    } else {
+      # run for mean only
+      sumv <- rowSums(v, dims = 2)
+      vbar <- sumv / N
+    }
+
+    normvbar <- sqrt(innerprod_q2(vbar, vbar))
+    delta <- 0.5
+    qmean <- cos(delta * normvbar) * qmean + sin(delta * normvbar) * vbar / normvbar
+    if (!is.null(basis)) qmean <- project_curve(qmean)
+    betamean <- q_to_curve(qmean)
+  }
+
+  list(qmean = qmean, betamean = betamean)
+}

--- a/R/utils.R
+++ b/R/utils.R
@@ -827,3 +827,16 @@ vandermonde_matrix <- function(alpha, n)  {
   res <- cbind(rep(1, length(alpha)), res)
   res
 }
+
+pairwise_amplitude_distance <- function(q1, q2, scale = FALSE) {
+  if (scale) {
+    q1dotq2 <- innerprod_q2(q1, q2)
+    if (q1dotq2 >  1) q1dotq2 <-  1
+    if (q1dotq2 < -1) q1dotq2 <- -1
+    d <- acos(q1dotq2)
+  } else {
+    v <- q1 - q2
+    d <- sqrt(innerprod_q2(v, v))
+  }
+  d
+}

--- a/R/utils.R
+++ b/R/utils.R
@@ -827,16 +827,3 @@ vandermonde_matrix <- function(alpha, n)  {
   res <- cbind(rep(1, length(alpha)), res)
   res
 }
-
-pairwise_amplitude_distance <- function(q1, q2, scale = FALSE) {
-  if (scale) {
-    q1dotq2 <- innerprod_q2(q1, q2)
-    if (q1dotq2 >  1) q1dotq2 <-  1
-    if (q1dotq2 < -1) q1dotq2 <- -1
-    d <- acos(q1dotq2)
-  } else {
-    v <- q1 - q2
-    d <- sqrt(innerprod_q2(v, v))
-  }
-  d
-}

--- a/man/calc_shape_dist.Rd
+++ b/man/calc_shape_dist.Rd
@@ -8,6 +8,7 @@ calc_shape_dist(
   beta1,
   beta2,
   mode = "O",
+  alignment = TRUE,
   rotation = TRUE,
   scale = TRUE,
   include.length = FALSE
@@ -24,6 +25,9 @@ will be aligned to \code{beta1}.}
 \item{mode}{A character string specifying whether the input curves should be
 considered open (\code{mode == "O"}) or closed (\code{mode == "C"}). Defaults to
 \code{"O"}.}
+
+\item{alignment}{A boolean value specifying whether the curves should be
+aligned before computing the distance matrix. Defaults to \code{TRUE}.}
 
 \item{rotation}{A boolean specifying whether the distance should be made
 invariant by rotation. Defaults to \code{TRUE}.}

--- a/man/calc_shape_dist.Rd
+++ b/man/calc_shape_dist.Rd
@@ -54,9 +54,9 @@ and scaling;
 \item \code{beta2n}: the input curve \code{beta2} after alignment and possible optimal
 rotation and scaling.
 \item \code{R}: the optimal rotation matrix that has been applied to the second curve;
-\item \code{betascale}: the optimal scaling factor that has been applied to the second
-curve;
 \item \code{gam}: the optimal warping function that has been applied to the second
+curve;
+\item \code{betascale}: the optimal scaling factor that has been applied to the second
 curve.
 }
 }

--- a/man/curve_dist.Rd
+++ b/man/curve_dist.Rd
@@ -7,6 +7,7 @@
 curve_dist(
   beta,
   mode = "O",
+  alignment = TRUE,
   rotation = FALSE,
   scale = FALSE,
   include.length = FALSE,
@@ -20,6 +21,9 @@ set of \eqn{N} curves of length \eqn{M} in \eqn{L}-dimensional space.}
 \item{mode}{A character string specifying whether the input curves should be
 considered open (\code{mode == "O"}) or closed (\code{mode == "C"}). Defaults to
 \code{"O"}.}
+
+\item{alignment}{A boolean value specifying whether the curves should be
+aligned before computing the distance matrix. Defaults to \code{TRUE}.}
 
 \item{rotation}{A boolean specifying whether the distance should be made
 invariant by rotation. Defaults to \code{TRUE}.}

--- a/man/curve_karcher_cov.Rd
+++ b/man/curve_karcher_cov.Rd
@@ -19,7 +19,7 @@ K covariance matrix
 Calculate Karcher Covariance of a set of curves
 }
 \examples{
-out <- curve_karcher_mean(beta[, , 1, 1:2], maxit = 2, parallel=FALSE)
+out <- curve_karcher_mean(beta[, , 1, 1:2], maxit = 2)
 # note: use more shapes, small for speed
 K <- curve_karcher_cov(out$v)
 }

--- a/man/curve_karcher_mean.Rd
+++ b/man/curve_karcher_mean.Rd
@@ -12,7 +12,7 @@ curve_karcher_mean(
   lambda = 0,
   maxit = 20,
   ms = c("mean", "median"),
-  parallel = TRUE
+  ncores = 1L
 )
 }
 \arguments{

--- a/man/curve_karcher_mean.Rd
+++ b/man/curve_karcher_mean.Rd
@@ -11,62 +11,91 @@ curve_karcher_mean(
   scale = TRUE,
   lambda = 0,
   maxit = 20,
-  ms = "mean",
+  ms = c("mean", "median"),
   parallel = TRUE
 )
 }
 \arguments{
-\item{beta}{Array of sizes \eqn{n \times T \times N} describing \eqn{N}
-curves of dimension \eqn{n} evaluated on \eqn{T} points}
+\item{beta}{A numeric array of shape \eqn{L \times M \times N} specifying an
+\eqn{N}-sample of \eqn{L}-dimensional curves evaluated on \eqn{M} points.}
 
-\item{mode}{Open (\code{"O"}) or Closed (\code{"C"}) curves}
+\item{mode}{A character string specifying whether the input curves should be
+considered open (\code{mode == "O"}) or closed (\code{mode == "C"}). Defaults to
+\code{"O"}.}
 
-\item{rotated}{Optimize over rotation (default = \code{TRUE})}
+\item{rotated}{A boolean specifying whether to make the metric
+rotation-invariant. Defaults to \code{FALSE}.}
 
-\item{scale}{scale curves to unit length (default = \code{TRUE})}
+\item{scale}{A boolean specifying whether the distance should be made
+invariant by scaling. This is effectively achieved by making SRVFs having
+unit length and switching to an appropriate metric on the sphere between
+normalized SRVFs. Defaults to \code{TRUE}.}
 
 \item{lambda}{A numeric value specifying the elasticity. Defaults to \code{0.0}.}
 
-\item{maxit}{maximum number of iterations}
+\item{maxit}{An integer value specifying the maximum number of iterations.
+Defaults to \code{20L}.}
 
-\item{ms}{string defining whether the Karcher mean (\code{"mean"}) or Karcher
-median (\code{"median"}) is returned (default = \code{"mean"})}
+\item{ms}{A character string specifying whether the Karcher mean ("mean") or
+Karcher median ("median") is returned. Defaults to \code{"mean"}.}
 
-\item{parallel}{A boolean specifying whether to run calculations in parallel.
-Defaults to \code{TRUE}.}
+\item{ncores}{An integer value specifying the number of cores to use for
+parallel computation. Defaults to \code{1L}. The maximum number of available
+cores is determined by the \strong{parallel} package. One core is always left
+out to avoid overloading the system.}
 }
 \value{
 An object of class \code{fdacurve} which is a list with the following
 components:
 \itemize{
-\item \code{mu}: mean srvf
-\item \code{beta}: centered curves
-\item \code{betamean}: mean or median curve
-\item \code{type}: string indicating whether mean or median is returned
-\item \code{v}: shooting vectors
-\item \code{q}: array of srvfs
-\item \code{gam}: array of warping functions
-\item \code{cent}: centers of original curves
-\item \code{len}: length of curves
-\item \code{len_q}: length of srvfs
-\item \code{mean_scale}: mean length
-\item \code{mean_scale_q}: mean length srvf
-\item \code{E}: energy
-\item \code{qun}: cost function
+\item beta: A numeric array of shape \eqn{L \times M \times N} specifying the
+\eqn{N}-sample of \eqn{L}-dimensional curves evaluated on \eqn{M} points.
+The curves might be slightly different from the input curves as they have
+been centered.
+\item \code{mu}: A numeric array of shape \eqn{L \times M} specifying the Karcher
+mean or median of the SRVFs of the input curves.
+\item \code{type}: A character string specifying whether the Karcher mean or median
+is returned.
+\item \code{betamean}: A numeric array of shape \eqn{L \times M} specifying the
+Karcher mean or median of the input curves.
+\item \code{v}: A numeric array of shape \eqn{L \times M \times N} specifying the
+shooting vectors.
+\item \code{q}: A numeric array of shape \eqn{L \times M \times N} specifying the
+SRVFs of the input curves.
+\item \code{E}: A numeric vector of shape \eqn{N} specifying XXX (TO DO)
+\item \code{cent}: A numeric array of shape \eqn{L \times M} specifying the centers
+of the input curves.
+\item \code{len}: A numeric vector of shape \eqn{N} specifying the length of the
+input curves.
+\item \code{len_q}: A numeric vector of shape \eqn{N} specifying the length of the
+SRVFs of the input curves.
+\item \code{qun}: A numeric vector of shape \eqn{maxit} specifying the consecutive
+values of the cost function.
+\item \code{mean_scale}: A numeric value specifying the mean length of the input
+curves.
+\item \code{mean_scale_q}: A numeric value specifying the mean length of the SRVFs
+of the input curves.
+\item \code{mode}: A character string specifying the mode of the input curves.
+\item \code{rotated}: A boolean specifying whether the metric is rotation-invariant.
+\item \code{scale}: A boolean specifying whether the metric is scale-invariant.
+\item \code{ms}: A character string specifying whether the Karcher mean or median is
+returned.
+\item \code{lambda}: A numeric value specifying the elasticity ??? (TO DO).
+\item \code{rsamps}: ??? (TO DO).
 }
 }
 \description{
 Calculates Karcher mean or median of a collection of curves using the elastic
-square-root velocity (srvf) framework.
+square-root velocity (SRVF) framework.
 }
 \examples{
-out <- curve_karcher_mean(beta[, , 1, 1:2], maxit = 2, parallel=FALSE)
+out <- curve_karcher_mean(beta[, , 1, 1:2], maxit = 2)
 # note: use more shapes, small for speed
 }
 \references{
 Srivastava, A., Klassen, E., Joshi, S., Jermyn, I., (2011). Shape
-analysis of elastic curves in euclidean spaces. Pattern Analysis and Machine
-Intelligence, IEEE Transactions on 33 (7), 1415-1428.
+analysis of elastic curves in Euclidean spaces. Pattern Analysis and
+Machine Intelligence, IEEE Transactions on 33 (7), 1415-1428.
 }
 \keyword{alignment}
 \keyword{srvf}

--- a/man/curve_principal_directions.Rd
+++ b/man/curve_principal_directions.Rd
@@ -32,7 +32,7 @@ Returns a list containing \item{s}{singular values}
 Calculate principal directions of a set of curves
 }
 \examples{
-out <- curve_karcher_mean(beta[, , 1, 1:2], maxit = 2, parallel=FALSE)
+out <- curve_karcher_mean(beta[, , 1, 1:2], maxit = 2)
 # note: use more shapes, small for speed
 K <- curve_karcher_cov(out$v)
 out <- curve_principal_directions(out$v, K, out$mu)

--- a/man/curve_to_q.Rd
+++ b/man/curve_to_q.Rd
@@ -2,31 +2,39 @@
 % Please edit documentation in R/curve_to_q.R
 \name{curve_to_q}
 \alias{curve_to_q}
-\title{Convert to SRVF space}
+\title{Curve to SRVF Space}
 \usage{
 curve_to_q(beta, scale = TRUE)
 }
 \arguments{
-\item{beta}{either a matrix of shape \eqn{n \times T} describing curve or
-multidimensional functional data in \eqn{R^n}, where \eqn{n} is the dimension
-and \eqn{T} is the number of time points}
+\item{beta}{A numeric matrix of shape \eqn{L \times M} specifying a curve on
+an \eqn{L}-dimensional space observed on \eqn{M} points.}
 
-\item{scale}{scale curve to unit length (default = \code{TRUE})}
+\item{scale}{A boolean value specifying whether the output SRVF function
+should be scaled to the hypersphere of \eqn{L^2}. When \code{scale} is \code{TRUE},
+the length of the original curve becomes irrelevant. Defaults to \code{TRUE}.}
 }
 \value{
-a numeric array of the same shape as the input array \code{beta} storing the
-SRVFs of the original curves.
+A list with the following components:
+\itemize{
+\item \code{q}: A numeric matrix of the same shape as the input matrix \code{beta} storing
+the (possibly scaled) SRVF of the original curve \code{beta};
+\item \code{len}: A numeric value specifying the length of the original curve;
+\item \code{lenq}: A numeric value specifying the \eqn{L^2} norm of the SRVF of the
+original curve.
+}
 }
 \description{
-This function converts curves or multidimesional functional data to SRVF
+This function computes the SRVF of a given curve. The function also outputs
+the length of the original curve and the \eqn{L^2} norm of the SRVF.
 }
 \examples{
 q <- curve_to_q(beta[, , 1, 1])$q
 }
 \references{
-Srivastava, A., Klassen, E., Joshi, S., Jermyn, I., (2011).
-Shape analysis of elastic curves in euclidean spaces. Pattern Analysis and M
-achine Intelligence, IEEE Transactions on 33 (7), 1415-1428.
+Srivastava, A., Klassen, E., Joshi, S., Jermyn, I., (2011). Shape
+analysis of elastic curves in Euclidean spaces. IEEE Transactions on
+Pattern Analysis and Machine Intelligence, \strong{33}(7), 1415-1428.
 }
 \keyword{alignment}
 \keyword{srvf}

--- a/man/multivariate_karcher_mean.Rd
+++ b/man/multivariate_karcher_mean.Rd
@@ -8,7 +8,7 @@ multivariate_karcher_mean(
   beta,
   rotation = FALSE,
   scale = FALSE,
-  maxit = 20,
+  maxit = 20L,
   ms = c("mean", "median"),
   ncores = 1L
 )
@@ -24,7 +24,8 @@ rotation-invariant. Defaults to \code{FALSE}.}
 \item{scale}{A boolean specifying whether to make the metric scale-invariant.
 Defaults to \code{FALSE}.}
 
-\item{maxit}{An integer value specifying the maximum number of iterations.}
+\item{maxit}{An integer value specifying the maximum number of iterations.
+Defaults to \code{20L}.}
 
 \item{ms}{A character string specifying whether the Karcher mean ("mean") or
 Karcher median ("median") is returned. Defaults to \code{"mean"}.}


### PR DESCRIPTION
- fixes in `find_rotation_seed_unique()` and `find_rotation_seed_coord()`; penalty option is added for both;
- refactoring in `calc_shape_dist()` and `curve_dist()` using newly defined internal functions `curve_to_srvf()` and `match_f2_to_f1()`;
- New internal functions in `utils-pointwise.R`:
    -  `amplitude_distance()` computes the distance in amplitude between two SRVFs supposed optimally transformed;
    -  `phase_distance()` computes the distance in phase between two SRVFs assumed to be already optimally transformed using the estimated $\gamma$;
    - `pointwise_mean()` computes or updates the Karcher mean or median using a set of SRVFs assumed to be already optimally transformed.

These internal functions should be helpful in making the code for Karcher mean computation clearer in the near future.

- Fixes in `kmeans_align()` which was broken; still needs an update though; in a near future as well.