### PR TITLE
Accommodate RcppArmadillo 14.4.0-0

### DIFF
--- a/src/bayesian.cpp
+++ b/src/bayesian.cpp
@@ -474,7 +474,7 @@ arma::vec findinv(arma::mat warps, int times)
   }
 
   arma::vec w = mean(psi_m,1);
-  arma::vec mupsi = w/as_scalar(sqrt(sum(pow(w,2)/(m-1))));
+  arma::vec mupsi = w/arma::as_scalar(sqrt(sum(pow(w,2)/(m-1))));
   arma::mat v_m(m-1,n);
   v_m.zeros();
   arma::vec mupsi_update(m-1);


### PR DESCRIPTION
Dear fdasrvf team,

Armadillo 14.4.0 has been released today, and Conrad and I had prepared this with the usual suite of reverse-dependency checks. A handful of packages, yours included, requires a minimal patch to compile as e.g. as_scalar now requires proper namespace scope.

This pull request is a one-line change after which the package (and its reverse depends) check fine as expected.

You can test it with the (GitHub and r-universe only) version 14.4.0-0 of RcppArmadillo which you can install via

```r
install.packages('RcppArmadillo', 
    repos = c('https://rcppcore.r-universe.dev',  'https://cran.r-project.org'))
```

We would like to bring the updated version to CRAN within three to four weeks so an update of your package would be greatly appreciated.  Please let us know if you have any questions; the issue is being tracked at https://github.com/RcppCore/RcppArmadillo/issues/462

Thanks!